### PR TITLE
Fix how to run a command on a node

### DIFF
--- a/doc/how-tos/_posts/2012-01-26-using-pallet-with-existing-servers.md
+++ b/doc/how-tos/_posts/2012-01-26-using-pallet-with-existing-servers.md
@@ -73,10 +73,10 @@ To test your configuration, trying running a simple `ls` command.
 (require 'pallet.action.exec-script 'pallet.phase)
 (pallet.core/lift
  (pallet.core/group-spec
-  "fe"
+  "tomcats"
   :phases {:configure (pallet.phase/phase-fn
                        (pallet.action.exec-script/exec-script (ls)))})
-  :compute my-data-center)
+ :compute my-data-center)
 {% endhighlight %}
 
 [node-types]: http://palletops.com/doc/reference/node-types "Defining server and group-specs"


### PR DESCRIPTION
`group-spec` takes a `group-name`, not `host-name` as the first argument.

Also the indentation was a bit misleading: it looked like the :compute
is an argument for `group-spec` instead of `lift`.
