### PR TITLE
Make phase documentation's terminology consistent

### DIFF
--- a/doc/reference/_posts/2012-01-13-actions.md
+++ b/doc/reference/_posts/2012-01-13-actions.md
@@ -31,9 +31,9 @@ achieve, so the `exec-script` actions allow you to execute arbitrary script.
 Files can be managed using the `file`, `symbolic-link`, and `fifo` actions.
 
 {% highlight clojure %}
-(file "some/path" :owner "user" :group "group" :mode "0644")
+(file "some/path" :owner "user", :group "group", :mode "0644")
 (symbolic-link "original/path" "link/path")
-(fifo "some/path" :owner "user" :group "group" :mode "0644")
+(fifo "some/path" :owner "user", :group "group", :mode "0644")
 {% endhighlight %}
 
 ## Simple Directory Management
@@ -41,7 +41,7 @@ Files can be managed using the `file`, `symbolic-link`, and `fifo` actions.
 Directories can be managed using the `directory`, and `directories` actions.
 
 {% highlight clojure %}
-(directory "some/path" :owner "user" :path true)
+(directory "some/path" :owner "user", :path true)
 (directories ["some/path" "other/path"] :owner "root")
 {% endhighlight %}
 
@@ -51,14 +51,14 @@ File contents can be manipulated with `remote-file`, `remote-directory`,
 `rsync-directory` and `sed`.
 
 {% highlight clojure %}
-(remote-file "some/path" :content "Some content" :owner "user" :path true)
+(remote-file "some/path" :content "Some content", :owner "user", :path true)
 (remote-directory "some/path" :local-file "my.tar.gz")
 (rsync-directory "local/path" "remote/path")
 {% endhighlight %}
 
 ## Packages
 
-Packages cn be controlled via `package`, `packages`, `package-manager`, `package-source`,
+Packages can be controlled via `package`, `packages`, `package-manager`, `package-source`,
 `add-rpm`, and `minimal-packages`.
 
 {% highlight clojure %}
@@ -75,7 +75,7 @@ Packages cn be controlled via `package`, `packages`, `package-manager`, `package
 Users and groups can be created and removed with `user` and `group`.
 
 {% highlight clojure %}
-(user "tomcat" :system true :shell "/bin/false" :group "tomcat")
+(user "tomcat" :system true, :shell "/bin/false", :group "tomcat")
 (group "tomcat")
 {% endhighlight %}
 

--- a/doc/reference/_posts/2012-01-14-logging.md
+++ b/doc/reference/_posts/2012-01-14-logging.md
@@ -8,7 +8,7 @@ summary: Pallet reference documentation for logging configuration
 ---
 
 Pallet uses [clojure.tools.logging](http://clojure.github.com/tools.logging) for
-it's logging. This supports multiple logging implementations. Pallet is most
+its logging. This supports multiple logging implementations. Pallet is most
 often run using [logback](http://logback.qos.ch/) as the logging implementation,
 via the [slf4j](http://slf4j.org) API support in `tools.logging`. It is also
 known to work with [log4j](http://logging.apache.org/log4j).

--- a/doc/reference/_posts/2012-01-14-node-push.md
+++ b/doc/reference/_posts/2012-01-14-node-push.md
@@ -25,7 +25,7 @@ The admin user can also be specified in the :environment
 
 {% highlight clojure %}
 (defpallet
-  :serivces
+  :services
     {:aws
       {:provider "ec2" :identity "key" :credential "secret-key"
        :environment
@@ -50,7 +50,7 @@ in the [`~/.pallet/config.clj`](file:~/.pallet/config.clj) file.
 ## Other SSH Key Strategies
 While convenient, having all your nodes authorise the same SSH key is not the
 best security practice.  Pallet allows you to install a function to provide an
-identity using you own strategy, with `pallet.core/with-middleware`. A
+identity using your own strategy, with `pallet.core/with-middleware`. A
 per node identity could be implemented using something like this:
 
 {% highlight clojure %}

--- a/doc/reference/_posts/2012-01-14-phases.md
+++ b/doc/reference/_posts/2012-01-14-phases.md
@@ -16,10 +16,10 @@ A phase is a function taking a single `session` argument, which it modifies and
 returns.  The `session` argument is passed to crate functions, which also
 return the `session`.
 
-## `phase` macro
+## `phase-fn` macro
 
-The `phase` macro is a convenience for defining a phase.  In the following
-example, the two server-spec definitions are equivalent. The `phase`
+The `phase-fn` macro is a convenience for defining a phase.  In the following
+example, the two server-spec definitions are equivalent. The `phase-fn`
 macro also adds some error checking of the session map.
 
 {% highlight clojure %}


### PR DESCRIPTION
I know that the `phase-fn` terminology might be rendered obsolete with the adoption of the State monad, but until that becomes standard it seems like a little bit of clarification for n00blets wouldn't hurt. (I know I stumbled on this when I came across the page, trying to figure out if there was a meaningful distinction between `phase` and `phase-fn`)
